### PR TITLE
Added missing header for uint32_t use

### DIFF
--- a/src/include/leeloo/interval.h
+++ b/src/include/leeloo/interval.h
@@ -30,6 +30,7 @@
 #define LEELOO_INTERVAL_H
 
 #include <algorithm>
+#include <cstdint>
 
 #include <leeloo/config.h>
 #include <leeloo/exports.h>


### PR DESCRIPTION
Unable to build on Debian stretch without this:
/libleeloo/src/include/leeloo/interval.h:127:67: error: 'uint32_t' was not declared in this scope
 LEELOO_TEMPLATE_EXPIMP template class LEELOO_API leeloo::interval<uint32_t>;
